### PR TITLE
Add support for TLS1.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,10 @@ resource "azurerm_resource_group" "sql" {
   }
 }
 
+locals {
+  minimum_tls_version = var.minimum_tls_version != null ? var.minimum_tls_version : startswith(local.server_name, "d-") ? "1.3" : "1.2"
+}
+
 resource "azurerm_mssql_server" "sqlsrv" {
   administrator_login                          = local.enable_local_auth ? var.admin_username : null
   administrator_login_password                 = local.enable_local_auth ? random_password.password[0].result : null

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_resource_group" "sql" {
 }
 
 locals {
-  minimum_tls_version = var.minimum_tls_version != null ? var.minimum_tls_version : startswith(local.server_name, "d-") ? "1.3" : "1.2"
+  minimum_tls_version = startswith(local.server_name, "d-") ? "1.3" : var.minimum_tls_version
 }
 
 resource "azurerm_mssql_server" "sqlsrv" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "minimum_tls_version" {
   default     = "1.2"
 
   validation {
-    condition     = (contains(["1.0", "1.1", "1.2"], var.minimum_tls_version))
+    condition     = (contains(["1.0", "1.1", "1.2", "1.3"], var.minimum_tls_version))
     error_message = "Valid values are '1.0', '1.1', or '1.2'."
   }
 }


### PR DESCRIPTION
- **Add support for TLS1.3 when it becomes available**
Should not be merged yet as azurerm resource does not support it.

<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Adds support for TLS1.3 and defaults to use it for dev environments.
```
