### PR TITLE
Add optional SQL elastic pool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,9 @@
 [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/miljodir/sql-server/azurerm/)
 
 Creates an Azure SQL Server with databases.
+Optionally provisions an Azure SQL elastic pool for all module-managed databases by using the remote Azure AVM elasticpool submodule.
 By default, local authentication and public network access is disabled.
+
+## Elastic pool
+
+Set `elastic_pool` to provision an elastic pool and place all databases from `databases` in that pool. Leave `elastic_pool = null` to preserve the existing single database compute behavior.

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,18 @@ locals {
   unique                        = var.unique == null ? random_string.unique[0].result : var.unique
   enable_local_auth             = var.azuread_administrator[0].azuread_authentication_only == true ? false : true
   server_name                   = var.server_name != null ? var.server_name : "${local.name_prefix}-sql${local.unique}-sqlsvr"
+  elastic_pool_enabled          = var.elastic_pool != null
+  elastic_pool_name             = try(var.elastic_pool.name, null) != null ? var.elastic_pool.name : "${local.server_name}-pool"
+  elastic_pool_per_database_settings = var.elastic_pool != null ? var.elastic_pool.per_database_settings : {
+    min_capacity = 0
+    max_capacity = 25
+  }
+  elastic_pool_sku = var.elastic_pool != null ? var.elastic_pool.sku : {
+    name     = "PremiumPool"
+    capacity = 125
+    tier     = "Premium"
+    family   = null
+  }
   public_network_access_enabled = local.allow_known_pips ? true : var.publicly_available ? true : false
   allow_known_pips              = split("-", local.name_prefix)[0] == "d" ? true : false
 
@@ -80,6 +92,26 @@ resource "azurerm_mssql_server" "sqlsrv" {
   }
 }
 
+module "elastic_pool" {
+  count  = local.elastic_pool_enabled == true ? 1 : 0
+  source = "git::https://github.com/Azure/terraform-azurerm-avm-res-sql-server.git//modules/elasticpool?ref=v0.2.0"
+
+  location = var.location
+  name     = local.elastic_pool_name
+
+  license_type                   = try(var.elastic_pool.license_type, "LicenseIncluded")
+  maintenance_configuration_name = try(var.elastic_pool.maintenance_configuration_name, "SQL_Default")
+  max_size_bytes                 = try(var.elastic_pool.max_size_bytes, null)
+  max_size_gb                    = try(var.elastic_pool.max_size_gb, 50)
+  per_database_settings          = local.elastic_pool_per_database_settings
+  sku                            = local.elastic_pool_sku
+  zone_redundant                 = try(var.elastic_pool.zone_redundant, true)
+
+  sql_server = {
+    resource_id = azurerm_mssql_server.sqlsrv.id
+  }
+}
+
 resource "azurerm_mssql_database" "db" {
   for_each = var.databases
 
@@ -88,15 +120,16 @@ resource "azurerm_mssql_database" "db" {
   # License type not allowed for serverless databases
   name                        = each.key
   server_id                   = azurerm_mssql_server.sqlsrv.id
-  sku_name                    = each.value.sku_name != null ? each.value.sku_name : "GP_S_Gen5_1"
-  min_capacity                = !startswith(each.value.sku_name, "GP_S") ? 0 : try(each.value.min_capacity, 0.5)
-  auto_pause_delay_in_minutes = !startswith(each.value.sku_name, "GP_S") ? null : try(each.value.auto_pause_delay_in_minutes, 60)
+  elastic_pool_id             = local.elastic_pool_enabled == true ? module.elastic_pool[0].resource_id : null
+  sku_name                    = each.value.sku_name != null ? each.value.sku_name : local.elastic_pool_enabled == true ? "ElasticPool" : "GP_S_Gen5_1"
+  min_capacity                = local.elastic_pool_enabled == true || !startswith(coalesce(each.value.sku_name, "GP_S_Gen5_1"), "GP_S") ? null : try(each.value.min_capacity, 0.5)
+  auto_pause_delay_in_minutes = local.elastic_pool_enabled == true || !startswith(coalesce(each.value.sku_name, "GP_S_Gen5_1"), "GP_S") ? null : try(each.value.auto_pause_delay_in_minutes, 60)
   storage_account_type        = each.value.storage_account_type != null ? each.value.storage_account_type : startswith(local.name_prefix, "p-") ? "Geo" : "Local"
 
   #   public_network_access_enabled = local.allow_known_pips ? true : var.publicly_available ? true : false
-  license_type                = each.value.capacity_unit == "Provisioned" && each.value.license_type != null ? each.value.license_type : null
+  license_type                = local.elastic_pool_enabled == true ? null : each.value.capacity_unit == "Provisioned" && each.value.license_type != null ? each.value.license_type : null
   collation                   = each.value.collation != null ? each.value.collation : "Danish_Norwegian_CI_AS"
-  max_size_gb                 = !startswith(each.value.sku_name, "GP_S") ? try(each.value.max_size_gb, 32) : try(each.value.max_size_gb, 50)
+  max_size_gb                 = !startswith(coalesce(each.value.sku_name, local.elastic_pool_enabled == true ? "ElasticPool" : "GP_S_Gen5_1"), "GP_S") ? try(each.value.max_size_gb, 32) : try(each.value.max_size_gb, 50)
   create_mode                 = each.value.create_mode
   creation_source_database_id = each.value.create_mode != "Default" && each.value.creation_source_database_id != null ? each.value.creation_source_database_id : null
   enclave_type                = each.value.create_mode == "Copy" ? "Default" : null
@@ -106,7 +139,7 @@ resource "azurerm_mssql_database" "db" {
     # Long term retention policy not allowed for serverless databases with auto-pause enabled.
     # Therefore the "hacky" determination of enabling LTR or not.
     # This logic will enable LTR by default if supported.
-    for_each = each.value.capacity_unit == "Provisioned" || each.value.auto_pause_delay_in_minutes == -1 ? ["true"] : []
+    for_each = local.elastic_pool_enabled == true || each.value.capacity_unit == "Provisioned" || each.value.auto_pause_delay_in_minutes == -1 ? ["true"] : []
     content {
       monthly_retention = lookup(long_term_retention_policy, "monthly_retention", "P6M")
       week_of_year      = lookup(long_term_retention_policy, "week_of_year", 1)
@@ -118,6 +151,18 @@ resource "azurerm_mssql_database" "db" {
   short_term_retention_policy {
     retention_days           = each.value.short_term_retention_policy == null ? 7 : each.value.short_term_retention_policy.retention_days
     backup_interval_in_hours = each.value.short_term_retention_policy == null ? 12 : each.value.short_term_retention_policy.backup_interval_in_hours
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.elastic_pool_enabled == false || each.value.sku_name == null || each.value.sku_name == "ElasticPool"
+      error_message = "When elastic_pool is set, database sku_name must be null or ElasticPool."
+    }
+
+    precondition {
+      condition     = local.elastic_pool_enabled == false || alltrue([each.value.capacity_unit == null, each.value.min_capacity == null, each.value.auto_pause_delay_in_minutes == null, each.value.license_type == null])
+      error_message = "When elastic_pool is set, database-specific serverless or provisioned compute settings must be omitted and configured through elastic_pool instead."
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -6,16 +6,11 @@ locals {
   server_name                   = var.server_name != null ? var.server_name : "${local.name_prefix}-sql${local.unique}-sqlsvr"
   elastic_pool_enabled          = var.elastic_pool != null
   elastic_pool_name             = try(var.elastic_pool.name, null) != null ? var.elastic_pool.name : "${local.server_name}-pool"
-  elastic_pool_per_database_settings = var.elastic_pool != null ? var.elastic_pool.per_database_settings : {
+  elastic_pool_per_database_settings = try(var.elastic_pool.per_database_settings, {
     min_capacity = 0
-    max_capacity = 25
-  }
-  elastic_pool_sku = var.elastic_pool != null ? var.elastic_pool.sku : {
-    name     = "PremiumPool"
-    capacity = 125
-    tier     = "Premium"
-    family   = null
-  }
+    max_capacity = 2
+  })
+  elastic_pool_sku = try(var.elastic_pool.sku, null)
   public_network_access_enabled = local.allow_known_pips ? true : var.publicly_available ? true : false
   allow_known_pips              = split("-", local.name_prefix)[0] == "d" ? true : false
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "server" {
   value       = azurerm_mssql_server.sqlsrv
 }
 
+output "elastic_pool" {
+  description = "The SQL elastic pool resource when created."
+  value       = local.elastic_pool_enabled == true ? module.elastic_pool[0].resource : null
+}
+
+output "elastic_pool_id" {
+  description = "The SQL elastic pool resource ID when created."
+  value       = local.elastic_pool_enabled == true ? module.elastic_pool[0].resource_id : null
+}
+
 output "private_ip" {
   description = "The database private IP if created."
   value       = var.create_private_endpoint == true ? azurerm_private_endpoint.sqlsrv_pe[0].private_service_connection[0].private_ip_address : ""

--- a/providers.tf
+++ b/providers.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0, < 5.0"
+      version = ">= 4.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/variables.tf
+++ b/variables.tf
@@ -127,14 +127,14 @@ variable "elastic_pool" {
     max_size_gb                    = optional(number, 50)
     per_database_settings = optional(object({
       min_capacity = optional(number, 0)
-      max_capacity = optional(number, 25)
+      max_capacity = optional(number, 2)
     }), {})
-    sku = object({
-      name     = string
-      capacity = number
-      tier     = string
-      family   = optional(string)
-    })
+    sku = optional(object({
+      name     = optional(string, "GP_Gen5")
+      capacity = optional(number, 2)
+      tier     = optional(string, "GeneralPurpose")
+      family   = optional(string, "Gen5")
+    }), {})
     zone_redundant = optional(bool, true)
   })
   description = "Optional elastic pool configuration for databases created by this module. When set, the module provisions an elastic pool using the Azure AVM elasticpool submodule and assigns all databases to it."

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,29 @@ variable "virtual_network_rules" {
 
 }
 
+variable "elastic_pool" {
+  type = object({
+    name                           = optional(string)
+    license_type                   = optional(string, "LicenseIncluded")
+    maintenance_configuration_name = optional(string, "SQL_Default")
+    max_size_bytes                 = optional(number)
+    max_size_gb                    = optional(number, 50)
+    per_database_settings = optional(object({
+      min_capacity = optional(number, 0)
+      max_capacity = optional(number, 25)
+    }), {})
+    sku = object({
+      name     = string
+      capacity = number
+      tier     = string
+      family   = optional(string)
+    })
+    zone_redundant = optional(bool, true)
+  })
+  description = "Optional elastic pool configuration for databases created by this module. When set, the module provisions an elastic pool using the Azure AVM elasticpool submodule and assigns all databases to it."
+  default     = null
+}
+
 variable "databases" {
   type = map(object({
     sku_name                    = optional(string),           # Sku name for database. Many possibilities .Defaults to "GP_S_Gen5_1" which means serverless 1 vcore.


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
## Summary
- add optional elastic pool support through the remote Azure AVM elasticpool submodule
- attach module-managed databases to the elastic pool when configured
- expose elastic pool outputs and update provider constraints/docs for AVM compatibility
```