### PR TITLE
admin password cannot be set if has been true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,10 @@ resource "azurerm_mssql_server" "sqlsrv" {
       type = "SystemAssigned"
     }
   }
+
+  lifecycle {
+    ignore_changes = [ administrator_login_password ] # `administrator_login_password` cannot be changed once `azuread_administrator.0.azuread_authentication_only = true`
+  }
 }
 
 module "elastic_pool" {


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Avoiding issues in edge cases where re-enabling local SQL auth

`administrator_login_password` cannot be changed once `azuread_administrator.0.azuread_authentication_only = true`
```
