### PR TITLE
Add output for script to run

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 output "access_script" {
-  description = "The script to grant your application access the database. This is currently done manually by a member of the ${var.azuread_administrator[0].login_username} Entra group. The group name not necessarily correct for your situation"
+  description = "The script to grant your application access the database. This is currently done manually by a member of the ${azurerm_mssql_server.sqlsrv.azuread_administrator[1].login_username} Entra group. The group name not necessarily correct for your situation"
   value       = <<-EOT
     CREATE USER [${local.possible_group_name}] FROM EXTERNAL PROVIDER; ALTER ROLE db_owner ADD MEMBER [${local.possible_group_name}];
   EOT

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,14 @@ output "private_ip" {
   description = "The database private IP if created."
   value       = var.create_private_endpoint == true ? azurerm_private_endpoint.sqlsrv_pe[0].private_service_connection[0].private_ip_address : ""
 }
+
+locals {
+  possible_group_name = "aks rbac ns ${split("-", local.name_prefix)[0]}-aks-${split("-", local.name_prefix)[1]} workload identities"
+}
+
+output "access_script" {
+  description = "The script to grant your application access the database. This is currently done manually by a member of the ${try(var.azuread_administrator[0].login_username, "MDIR SQL Admins PIM")} Entra group. The group name not necessarily correct for your situation"
+  value       = <<-EOT
+    CREATE USER [${local.possible_group_name}] FROM EXTERNAL PROVIDER; ALTER ROLE db_owner ADD MEMBER [${local.possible_group_name}];
+  EOT
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 output "access_script" {
-  description = "The script to grant your application access the database. This is currently done manually by a member of the ${azurerm_mssql_server.sqlsrv.azuread_administrator[1].login_username} Entra group. The group name not necessarily correct for your situation"
+  description = "The script to grant your application access the database. This is currently done manually by a member of the SQL Server's Entra group admins. The group name not necessarily correct for your situation"
   value       = <<-EOT
     CREATE USER [${local.possible_group_name}] FROM EXTERNAL PROVIDER; ALTER ROLE db_owner ADD MEMBER [${local.possible_group_name}];
   EOT

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 output "access_script" {
-  description = "The script to grant your application access the database. This is currently done manually by a member of the ${try(var.azuread_administrator[0].login_username, "MDIR SQL Admins PIM")} Entra group. The group name not necessarily correct for your situation"
+  description = "The script to grant your application access the database. This is currently done manually by a member of the ${var.azuread_administrator[0].login_username} Entra group. The group name not necessarily correct for your situation"
   value       = <<-EOT
     CREATE USER [${local.possible_group_name}] FROM EXTERNAL PROVIDER; ALTER ROLE db_owner ADD MEMBER [${local.possible_group_name}];
   EOT


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Adds SQL output which needs to be run to grant access.
The group name will not always be correct, especially if using managed identity.
In some cases db_owner will not be required (depends on how migrations are run)
```
